### PR TITLE
Wrap targets in single quotes / escape quotation marks

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -90,14 +90,14 @@ func slice2String(slice []string) string {
 		buffer.WriteString(slice[0])
 		return buffer.String()
 	}
-	buffer.WriteString(`{`)
+	buffer.WriteString(`{'`)
 	for i, item := range slice {
 		buffer.WriteString(item)
 		if i < len(slice)-1 {
-			buffer.WriteString(",")
+			buffer.WriteString("','")
 		}
 	}
-	buffer.WriteString(`}`)
+	buffer.WriteString(`'}`)
 	return buffer.String()
 }
 

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -164,8 +164,8 @@ func Test_slice2String(t *testing.T) {
 	}{
 		{
 			name:  "スライスをストリングに変換",
-			input: []string{"aws_iam_role_policy_attachment.local_poilcy_attachment", "aws_lambda_function.local_lambda", "aws_iam_policy.local_policy", "aws_lambda_event_source_mapping.local_mapping"},
-			want:  "{aws_iam_role_policy_attachment.local_poilcy_attachment,aws_lambda_function.local_lambda,aws_iam_policy.local_policy,aws_lambda_event_source_mapping.local_mapping}",
+			input: []string{"aws_iam_role_policy_attachment.local_poilcy_attachment", "aws_lambda_function.local_lambda", "aws_iam_policy.local_policy", "aws_lambda_event_source_mapping.local_mapping", "aws_lambda_function.lambda_set[\"test\"]"},
+			want:  "{'aws_iam_role_policy_attachment.local_poilcy_attachment','aws_lambda_function.local_lambda','aws_iam_policy.local_policy','aws_lambda_event_source_mapping.local_mapping','aws_lambda_function.lambda_set[\"test\"]'}",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
`tftarget apply` fails if selected resources have quotes in their name. These changes wraps all targets in single quotes to avoid this issue.

Addresses https://github.com/future-architect/tftarget/issues/16