### PR TITLE
Release for v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.6](https://github.com/future-architect/tftarget/compare/v0.0.5...v0.0.6) - 2023-10-23
+- fix: SetVersionInfo duplication by @orangekame3 in https://github.com/future-architect/tftarget/pull/24
+
 ## [v0.0.5](https://github.com/future-architect/tftarget/compare/v0.0.4...v0.0.5) - 2023-10-22
 - [add version file] by @orangekame3 in https://github.com/future-architect/tftarget/pull/20
 - [add] add codeowners by @orangekame3 in https://github.com/future-architect/tftarget/pull/22

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ package cmd
 import "fmt"
 
 // Version is a version of this application.
-const Version = "0.0.5"
+const Version = "0.0.6"
 
 // SetVersionInfo sets version and date to rootCmd
 func SetVersionInfo(version, date string) {


### PR DESCRIPTION
This pull request is for the next release as v0.0.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: SetVersionInfo duplication by @orangekame3 in https://github.com/future-architect/tftarget/pull/24


**Full Changelog**: https://github.com/future-architect/tftarget/compare/v0.0.5...v0.0.6