### PR TITLE
Fix genTargetCmd function to deal with multiple and single selections

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -105,7 +105,8 @@ func slice2String(slice []string) string {
 
 func genTargetCmd(cmd *cobra.Command, action, target string) bytes.Buffer {
   var buf bytes.Buffer
-  buf.WriteString("terraform " + action)
+  executable, _ := cmd.Flags().GetString("executable")
+  buf.WriteString(executable + " " + action)
   target = strings.TrimSpace(target)
   if strings.HasPrefix(target, "{") && strings.HasSuffix(target, "}") {
     // Handle matrix of targets

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -102,11 +102,23 @@ func slice2String(slice []string) string {
 }
 
 func genTargetCmd(cmd *cobra.Command, action, target string) bytes.Buffer {
-	var buf bytes.Buffer
-	buf.WriteString("terraform " + action + " -target=" + target)
-	p, _ := cmd.Flags().GetInt("parallel")
-	buf.WriteString(fmt.Sprintf(" --parallelism=%d", p))
-	return buf
+  var buf bytes.Buffer
+  buf.WriteString("terraform " + action)
+  target = strings.TrimSpace(target)
+  if strings.HasPrefix(target, "{") && strings.HasSuffix(target, "}") {
+    // Handle matrix of targets
+    target = strings.Trim(target, "{}") // Remove surrounding braces
+    targetList := strings.Split(target, ",")
+    for _, t := range targetList {
+      buf.WriteString(" -target=" + strings.TrimSpace(t))
+      }
+  } else {
+    // Handle single target
+    buf.WriteString(" -target=" + target)
+  }
+  p, _ := cmd.Flags().GetInt("parallel")
+  buf.WriteString(fmt.Sprintf(" --parallelism=%d", p))
+  return buf
 }
 
 func isYes(reader *bufio.Reader) bool {


### PR DESCRIPTION
Previous code only managed well single selection, multiple selection caused error.

The fix applies and correct this for apply, plan & destroy without affecting to any other feature.

It fixes also https://github.com/future-architect/tftarget/issues/12

	modified:   cmd/util.go