### PR TITLE
Release for v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.8](https://github.com/future-architect/tftarget/compare/v0.0.7...v0.0.8) - 2024-12-24
+- Add parameter for terraform executable (for compatibility with OpenTofu) by @zekroTJA in https://github.com/future-architect/tftarget/pull/31
+- Fix genTargetCmd function to deal with multiple and single selections by @jmonfar in https://github.com/future-architect/tftarget/pull/32
+
 ## [v0.0.7](https://github.com/future-architect/tftarget/compare/v0.0.6...v0.0.7) - 2023-10-23
 - fix:remove unused fmt by @orangekame3 in https://github.com/future-architect/tftarget/pull/26
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ package cmd
 import "fmt"
 
 // Version is a version of this application.
-const Version = "0.0.7"
+const Version = "0.0.8"
 
 // SetVersionInfo sets version and date to rootCmd
 func SetVersionInfo(version, date string) {


### PR DESCRIPTION
This pull request is for the next release as v0.0.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Add parameter for terraform executable (for compatibility with OpenTofu) by @zekroTJA in https://github.com/future-architect/tftarget/pull/31
* Fix genTargetCmd function to deal with multiple and single selections by @jmonfar in https://github.com/future-architect/tftarget/pull/32

## New Contributors
* @zekroTJA made their first contribution in https://github.com/future-architect/tftarget/pull/31
* @jmonfar made their first contribution in https://github.com/future-architect/tftarget/pull/32

**Full Changelog**: https://github.com/future-architect/tftarget/compare/v0.0.7...v0.0.8